### PR TITLE
handle_valid_body without state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use gotham::handler::{HandlerFuture, IntoHandlerError};
 use gotham::helpers::http::response::create_empty_response;
 use gotham::router::builder::{build_simple_router, DefineSingleRoute, DrawRoutes};
 use gotham::router::Router;
-use gotham::state::{FromState, State};
+use gotham::state::{FromState, State, StateData};
 use hyper::header::HeaderValue;
 use hyper::{Body, Chunk, HeaderMap, Method, Response, StatusCode, Uri, Version};
 use log::info;
@@ -39,6 +39,13 @@ impl Mailer for DummyMailer{
     }
 }
 
+/*
+#[derive(StateData)]
+struct SuperDuperStateObject{
+    foo: u32
+}
+*/
+
 fn print_request_elements(state: &State) {
     let method = Method::borrow_from(state);
     let uri = Uri::borrow_from(state);
@@ -56,6 +63,12 @@ fn post_handler(mut state: State) -> Box<HandlerFuture> {
         .concat2()
         .then(|full_body| match full_body {
             Ok(valid_body) => future::ok({
+
+                /*
+                    Since we now call handle_valid_body synchronously, we can extract things from the sate and borrow it to the function
+                    let whatever = state.try_borrow::<SuperDuperStateObject>().unwrap();
+                    handle_valid_body(valid_body, DummyMailer, whatever);
+                */                    
 
                 let mail_res = handle_valid_body(valid_body, DummyMailer);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,19 +22,19 @@ mod mail;
 const SMTP_PASSWORD_KEY: &'static str = "MK_RUST_MAILER_SMTP_PASSWORD";
 
 trait Mailer{
-    fn send_mail(cfg: mail::Config, mail: mail::ContactMail);
+    fn send_mail(&self, cfg: mail::Config, mail: mail::ContactMail);
 }
 
 struct WhateverMailer;
 struct DummyMailer;
 
 impl Mailer for WhateverMailer{
-    fn send_mail(cfg: mail::Config, mail: mail::ContactMail){
+    fn send_mail(&self, cfg: mail::Config, mail: mail::ContactMail){
         mail::send_contact_mail(cfg,mail);
     }
 }
 impl Mailer for DummyMailer{
-    fn send_mail(cfg: mail::Config, mail: mail::ContactMail){
+    fn send_mail(&self, cfg: mail::Config, mail: mail::ContactMail){
         unimplemented!();
     }
 }
@@ -73,6 +73,8 @@ fn handle_valid_body<M: Mailer>(body: Chunk, state: State, mailer: M) -> (State,
     println!("Body: {}", body_content);
 
     let mail_data: mail::ContactMail = serde_json::from_str(body_content.as_str()).unwrap();
+
+    mailer.send_mail(mail_config, mail_data);
 
     //send_fn(mail_config, mail_data);
     let mut res = create_empty_response(&state, StatusCode::OK);


### PR DESCRIPTION
I implemented one solution that I didn't come up with in our call: the `handle_valid_body` function was decoupled from the gotham-specific types. 
- `handle_valid_body` can now be tested independently, not requiring the `state` object, returning a result type that can be mapped to a http response in the callee
- If we later need to access something from the mailing function, that is located in the state, the callee can extract it and handle occuring erros. the test functions can construct these necessary objects directly. See the comments in `post_handler` for an example.
- I moved the mail function call to a trait for my own convenience
- The added headers should probably be checked and set in a middleware to minimize duplication